### PR TITLE
[11.0][IMP] hr_holidays_manager_approval: Leaves Manager added for approvals

### DIFF
--- a/hr_holidays_manager_approval/README.rst
+++ b/hr_holidays_manager_approval/README.rst
@@ -22,6 +22,9 @@ Employee Leaves - Manager approval
 Only user that is the Employee Manager of a certain employee can approve,
 validate or refuese that employee leaves.
 
+In order to prevent approval blocking (e.g. when the Employee Manager is out
+of the office), a Leaves Manager can also make the same actions.
+
 **Table of contents**
 
 .. contents::

--- a/hr_holidays_manager_approval/__manifest__.py
+++ b/hr_holidays_manager_approval/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "category": "Human Resources",
     "website": "https://github.com/solvosci/slv-hr",
     "depends": ["hr_holidays"],

--- a/hr_holidays_manager_approval/i18n/es.po
+++ b/hr_holidays_manager_approval/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-11 08:45+0000\n"
-"PO-Revision-Date: 2022-10-11 08:45+0000\n"
+"POT-Creation-Date: 2022-12-16 11:41+0000\n"
+"PO-Revision-Date: 2022-12-16 11:41+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -40,8 +40,8 @@ msgid "My Manager Leaves"
 msgstr "Ausencias a administrar"
 
 #. module: hr_holidays_manager_approval
-#: code:addons/hr_holidays_manager_approval/models/hr_holidays.py:53
+#: code:addons/hr_holidays_manager_approval/models/hr_holidays.py:59
 #, python-format
-msgid "Only %s can approve/validate/refuse leaves for the employee %s"
-msgstr "Solo %s puede aprobar/validar/rechazar peticiones de ausencia del empleado %s"
+msgid "Only %s or a Leave Manager can approve/validate/refuse leaves for the employee %s"
+msgstr "Solo %s o un Responsable de Ausencias puede aprobar/validar/rechazar peticiones de ausencia del empleado %s"
 

--- a/hr_holidays_manager_approval/i18n/hr_holidays_manager_approval.pot
+++ b/hr_holidays_manager_approval/i18n/hr_holidays_manager_approval.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-11 08:45+0000\n"
-"PO-Revision-Date: 2022-10-11 08:45+0000\n"
+"POT-Creation-Date: 2022-12-16 11:40+0000\n"
+"PO-Revision-Date: 2022-12-16 11:40+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -38,8 +38,8 @@ msgid "My Manager Leaves"
 msgstr ""
 
 #. module: hr_holidays_manager_approval
-#: code:addons/hr_holidays_manager_approval/models/hr_holidays.py:53
+#: code:addons/hr_holidays_manager_approval/models/hr_holidays.py:59
 #, python-format
-msgid "Only %s can approve/validate/refuse leaves for the employee %s"
+msgid "Only %s or a Leave Manager can approve/validate/refuse leaves for the employee %s"
 msgstr ""
 

--- a/hr_holidays_manager_approval/models/hr_holidays.py
+++ b/hr_holidays_manager_approval/models/hr_holidays.py
@@ -48,8 +48,17 @@ class HrHolidays(models.Model):
 
     @api.one
     def _check_security_manager_rights(self):
-        if self.manager_user_id.id != self.env.user.id:
+        if (
+            self.manager_user_id.id != self.env.user.id
+            and
+            not self.env.user.has_group(
+                "hr_holidays.group_hr_holidays_manager"
+            )
+        ):
             raise UserError(
-                _("Only %s can approve/validate/refuse leaves for the employee %s")
+                _(
+                    "Only %s or a Leave Manager can approve/validate/refuse"
+                    " leaves for the employee %s"
+                )
                 % (self.manager_user_id.name, self.employee_id.name)
             )

--- a/hr_holidays_manager_approval/readme/DESCRIPTION.rst
+++ b/hr_holidays_manager_approval/readme/DESCRIPTION.rst
@@ -1,2 +1,5 @@
 Only user that is the Employee Manager of a certain employee can approve,
 validate or refuese that employee leaves.
+
+In order to prevent approval blocking (e.g. when the Employee Manager is out
+of the office), a Leaves Manager can also make the same actions.

--- a/hr_holidays_manager_approval/static/description/index.html
+++ b/hr_holidays_manager_approval/static/description/index.html
@@ -370,6 +370,8 @@ ul.auto-toc {
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/licence-LGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/solvosci/slv-hr/tree/11.0/hr_holidays_manager_approval"><img alt="solvosci/slv-hr" src="https://img.shields.io/badge/github-solvosci%2Fslv--hr-lightgray.png?logo=github" /></a></p>
 <p>Only user that is the Employee Manager of a certain employee can approve,
 validate or refuese that employee leaves.</p>
+<p>In order to prevent approval blocking (e.g. when the Employee Manager is out
+of the office), a Leaves Manager can also make the same actions.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">


### PR DESCRIPTION
With this improvement, in order to prevent approval blocking (e.g. when the Employee Manager is out of the office), a Leaves Manager can also make the same actions initially reserved to the Employee Manager