### PR TITLE
[17.0][FIX] hr_expense_hide_taxes: expense form - hide all pending taxes data

### DIFF
--- a/hr_expense_hide_taxes/__manifest__.py
+++ b/hr_expense_hide_taxes/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Operations/HR",
     "website": "https://github.com/solvosci/slv-hr",
     "depends": [

--- a/hr_expense_hide_taxes/views/hr_expense_views.xml
+++ b/hr_expense_hide_taxes/views/hr_expense_views.xml
@@ -5,7 +5,10 @@
         <field name="model">hr.expense</field>
         <field name="inherit_id" ref="hr_expense.hr_expense_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='tax_ids']" position="attributes">
+            <xpath expr="//label[@for='tax_ids']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='tax_ids']/.." position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
Total taxes amount was still visible

<img width="417" height="275" alt="imagen" src="https://github.com/user-attachments/assets/c17e402f-0208-45b6-8fd3-72a2711452eb" />


cc @IriaAlonso 